### PR TITLE
Fix minor issues and add unary instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This compiler currently supports the following btor2 instructions:
 | `<lid> state <sid> <name>` | Declares a stateful element |
 | `<lid> init <sid> <state> <val>` | Initializes a state |
 | `<lid> next <sid> <state> <next>` | Sets the transition logic of a state |
-| `<lid> slice <sid> <op> <w> <lb>` | Extracts bits `[lb:lb+w]` from a result |
+| `<lid> slice <sid> <op> <hb> <lb>` | Extracts bits `[hb:lb]` from a result |
 | `<lid> ite <sid> <cond> <t> <f>` | If-then-else expression |
 | `<lid> implies <sid> <lhs> <rhs>` | Logical implication |
 | `<lid> iff <sid> <lhs> <rhs>` | If and only if expression |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
 ]
 keywords = ["btor2", "parser", "compiler"]
 requires-python = ">=3.10"
+dependencies = [
+	"tqdm>=4.67.1"
+]
 
     [project.scripts]
     btoropt = "btoropt.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,8 @@ typing-extensions==4.12.2
     # via black
 wheel==0.43.0
     # via pip-tools
+tqdm==4.67.1
+
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -169,15 +169,19 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
 
         case "input":
             # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "input instruction must be of the form: <lid> input <sid> <name>. Found: " + line
+            assert len(inst) >= 3,\
+                "input instruction must be of the form: <lid> input <sid> [<name>]. Found: " + line
 
             # Find the sort associated to this instruction
             sort = find_inst(p, int(inst[2]))
             assert isinstance(sort, Sort), f"Input sort must be a Sort. Found: " + line
 
+            if len(inst) >= 4:
+                name = inst[3].strip()
+            else:
+                name = f"input_{inst[0]}"
             # Construct instruction
-            op = Input(lid, sort, inst[3])
+            op = Input(lid, sort, name)
 
         case "output":
             # Sanity check: verify that instruction is well formed
@@ -284,13 +288,16 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
 
         case "state":
             # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "state instruction must be of the form: <lid> state <sid> <name>. Found: " + line
+            assert len(inst) >= 3,\
+                "state instruction must be of the form: <lid> state <sid> [<name>]. Found: " + line
 
             # Find the operands associated to this instruction
             sort = find_inst(p, int(inst[2]))
             assert isinstance(sort, Sort), f"State sort must be a Sort. Found: " + line
-            name = inst[3].strip()
+            if len(inst) >= 4:
+                name = inst[3].strip()
+            else:
+                name = f"state_{inst[0]}"
 
             # Construct instruction
             op = State(lid, sort, name)
@@ -324,16 +331,16 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
         case "slice":
             # Sanity check: verify that instruction is well formed
             assert len(inst) >= 6,\
-                "sort instruction must be of the form: <lid> slice <sid> <opid> <width> <lowbit>. Found: " + line
+                "slice instruction must be of the form: <lid> slice <sid> <opid> <highbit> <lowbit>. Found: " + line
 
             # Find the operands associated to this instruction
             sort = find_inst(p, int(inst[2]))
             operand = find_inst(p, int(inst[3]))
-            width = int(inst[4])
+            highbit = int(inst[4])
             lowbit = int(inst[5])
 
             # Construct instruction
-            op = Slice(lid, sort, operand, width, lowbit)
+            op = Slice(lid, sort, operand, highbit, lowbit)
 
         case "ite":
             # Sanity check: verify that instruction is well formed
@@ -547,7 +554,7 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
         case "not":
             # Sanity check: verify that instruction is well formed
             assert len(inst) >= 4,\
-                "sort instruction must be of the form: <lid> not <sid> <cond>. Found: " + line
+                "not instruction must be of the form: <lid> not <sid> <cond>. Found: " + line
 
             # Find the operands associated to this instruction
             sort = find_inst(p, int(inst[2]))
@@ -555,6 +562,73 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
 
             # Construct instruction
             op = Not(lid, sort, cond)
+
+        case "inc":
+            # Sanity check: verify that instruction is well formed
+            assert len(inst) >= 4,\
+                "inc instruction must be of the form: <lid> inc <sid> <stateid>. Found: " + line
+
+            # Find the operands associated to this instruction
+            sort = find_inst(p, int(inst[2]))
+            state = find_inst(p, int(inst[3]))
+
+            # Construct instruction
+            op = Inc(lid, sort, state)
+
+        case "dec":
+            # Sanity check: verify that instruction is well formed
+            assert len(inst) >= 4,\
+                "dec instruction must be of the form: <lid> dec <sid> <stateid>. Found: " + line
+
+            # Find the operands associated to this instruction
+            sort = find_inst(p, int(inst[2]))
+            state = find_inst(p, int(inst[3]))
+
+            # Construct instruction
+            op = Dec(lid, sort, state)
+
+        case "neg":
+            # Sanity check: verify that instruction is well formed
+            assert len(inst) >= 4,\
+                "neg instruction must be of the form: <lid> neg <sid> <cond>. Found: " + line
+
+            # Find the operands associated to this instruction
+            sort = find_inst(p, int(inst[2]))
+            cond = find_inst(p, int(inst[3]))
+
+            # Construct instruction
+            op = Neg(lid, sort, cond)
+
+        case "redor":
+            # Sanity check: verify that instruction is well formed
+            assert len(inst) >= 4,\
+                "redor instruction must be of the form: <lid> redor <srtid> <sid>. Found: " + line
+            
+            # Find the operands associated to this instruction
+            sort = find_inst(p, int(inst[2]))
+            cond = find_inst(p, int(inst[3]))
+
+            # Construct instruction
+            op = Redor(lid, sort, cond)
+
+        case "redand":
+            # Sanity check: verify that instruction is well formed
+            assert len(inst) >= 4,\
+                "redand instruction must be of the form: <lid> redand <srtid> <sid>. Found: " + line
+            # Find the operands associated to this instruction
+            sort = find_inst(p, int(inst[2]))
+            cond = find_inst(p, int(inst[3]))
+            # Construct instruction
+            op = Redand(lid, sort, cond)
+        case "redxor":
+            # Sanity check: verify that instruction is well formed
+            assert len(inst) >= 4,\
+                "redxor instruction must be of the form: <lid> redxor <srtid> <sid>. Found: " + line
+            # Find the operands associated to this instruction
+            sort = find_inst(p, int(inst[2]))
+            cond = find_inst(p, int(inst[3]))
+            # Construct instruction
+            op = Redxor(lid, sort, cond)
 
         case "eq":
             # Sanity check: verify that instruction is well formed
@@ -688,16 +762,21 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
 
         case "uext":
             # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 6,\
-                "sort instruction must be of the form: <lid> uext <sid> <opid> <width> <name>. Found: " + line
+            assert len(inst) >= 5,\
+                "sort instruction must be of the form: <lid> uext <sid> <opid> <width> [<name>]. Found: " + line
 
             # Find the operands associated to this instruction
             sort = find_inst(p, int(inst[2]))
             operand = find_inst(p, int(inst[3]))
             width = int(inst[4])
 
+            if len(inst) >= 6:
+                name = inst[5].strip()
+            else:
+                name = f"uext_{inst[0]}"
+
             # Construct instruction
-            op = Uext(lid, sort, operand, width, inst[5])
+            op = Uext(lid, sort, operand, width, name)
 
         case _:
             print(f"Unsupported operation type: {tag} in {line}")

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -17,6 +17,7 @@
 ##########################################################################
 
 from .program import *
+from tqdm import tqdm
 
 # Retrieves an instruction with the given ID from the given standard program
 # This is a safe wrapper around `get_inst` and enforces that the given
@@ -823,7 +824,7 @@ def parse_file(inp: list[str]) -> Program:
 def parse(inp: list[str]) -> list[Instruction]:
     # Split the string into instructions and read them 1 by 1
     p = []
-    for line in inp:
+    for line in tqdm(inp, desc="Parsing BTOR2"):
         op = parse_inst(line, p)
         if op is not None:
             p.append(op)

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -19,7 +19,7 @@
 from .program import *
 
 # Retrieves an instruction with the given ID from the given standard program
-# This is a safe wrapper around `get_inst` and enforces that the given 
+# This is a safe wrapper around `get_inst` and enforces that the given
 # ID must be correct.
 def find_inst(p: list[Instruction], id: int) -> Instruction:
     inst = get_inst(p, id)
@@ -52,7 +52,7 @@ def scan_body(inp: list[str], i: int) -> tuple[list[str], int]:
     return (res, i)
 
 # Parses a ref instruction (only custom inst that is allowed in both modules and contracts)
-# @param inst: the pre-split ref instruction to be parsed 
+# @param inst: the pre-split ref instruction to be parsed
 # @param modules: the list of already parsed modules that can be referenced
 def parse_ref(inst: list[str], modules: list[Module]) -> Ref:
     ## Sanity check: Must be a ref instruction
@@ -455,7 +455,7 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
             # Find the operands associated to this instruction
             sort = find_inst(p, int(inst[2]))
             op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(int(inst[4]))
+            op2 = find_inst(p, int(inst[4]))
 
             # Construct instruction
             op = Smod(lid, sort, op1, op2)
@@ -603,7 +603,7 @@ def parse_inst(line: str, p: list[Instruction]) -> Instruction:
             # Sanity check: verify that instruction is well formed
             assert len(inst) >= 4,\
                 "redor instruction must be of the form: <lid> redor <srtid> <sid>. Found: " + line
-            
+
             # Find the operands associated to this instruction
             sort = find_inst(p, int(inst[2]))
             cond = find_inst(p, int(inst[3]))
@@ -800,7 +800,7 @@ def parse_file(inp: list[str]) -> Program:
                 b = parse_module_body(body, m)
                 # Create and store the module
                 m.append(Module(name, b))
-                            
+
             case "contract":
                 name = symbols[1]
                 assert check_name(name, m), f"Contract name {name} is not defined!"
@@ -816,7 +816,7 @@ def parse_file(inp: list[str]) -> Program:
             case _:
                 print(f"Unsupported structure: {tag} is not module | contract")
                 exit(1)
-            
+
     return Program(m, c)
 
 # Parse a standard btor2 file, does not handle custom instructions

--- a/src/btoropt/program.py
+++ b/src/btoropt/program.py
@@ -23,7 +23,9 @@ tags = ["sort","input", "output", "bad", "constraint", "zero",
         "one", "ones", "constd", "consth", "const", "state",
         "init", "next", "slice", "ite", "implies", "iff",
         "add", "sub", "mul", "sdiv", "udiv", "smod", "sll",
-        "srl", "sra", "and", "or", "xor", "concat", "not",
+        "srl", "sra", "and", "or", "xor", "concat", 
+        # Unary operations
+        "not", "inc", "dec", "neg", "redor", "redxor", "redand",
         "eq", "neq", "ugt", "sgt", "ugte", "sgte", "ult",
         "slt", "ulte", "slte", "uext", "sext"]
 
@@ -148,6 +150,30 @@ class Not(Instruction):
     def __init__(self, lid: int, sort: Sort, cond: Instruction):
         super().__init__(lid, "not", [sort, cond])
 
+class Inc(Instruction):
+    def __init__(self, lid: int, sort: Sort, op1: Instruction):
+        super().__init__(lid, "inc", [sort, op1])
+
+class Dec(Instruction):
+    def __init__(self, lid: int, sort: Sort, op1: Instruction):
+        super().__init__(lid, "dec", [sort, op1])
+
+class Neg(Instruction):
+    def __init__(self, lid: int, sort: Sort, op1: Instruction):
+        super().__init__(lid, "neg", [sort, op1])
+
+class Redor(Instruction):
+    def __init__(self, lid: int, sort: Sort, op1: Instruction):
+        super().__init__(lid, "redor", [sort, op1])
+
+class Redxor(Instruction):
+    def __init__(self, lid: int, sort: Sort, op1: Instruction):
+        super().__init__(lid, "redxor", [sort, op1])
+
+class Redand(Instruction):
+    def __init__(self, lid: int, sort: Sort, op1: Instruction):
+        super().__init__(lid, "redand", [sort, op1])
+
 ## Constants: always of the form Instruction + sort + value ##
 
 class Constd(Instruction):
@@ -210,13 +236,14 @@ class Next(Instruction):
         self.stid = state.lid
 
 class Slice(Instruction):
-    def __init__(self, lid: int, sort: Sort, op: Instruction, width: int, lowbit: int):
+    def __init__(self, lid: int, sort: Sort, op: Instruction, highbit: int, lowbit: int):
         super().__init__(lid, "slice", [sort, op])
-        self.width: int = width
+        self.highbit: int = highbit
         self.lowbit: int = lowbit
+        self.width = (self.highbit-self.lowbit+1)
 
     def eq(self, inst) -> bool:
-        return super().eq(inst) and self.width == inst.width and self.lowbit == inst.lowbit
+        return super().eq(inst) and self.highbit == inst.highbit and self.lowbit == inst.lowbit
 
     def serialize(self) -> str:
         return super().serialize() + str(self.width) + " " + str(self.lowbit)


### PR DESCRIPTION
- Add unary instructions from spec (https://cs.stanford.edu/~preiner/publications/2018/NiemetzPreinerWolfBiere-CAV18.pdf)
- Fix asserts to match BTOR2 specification (input, state instructions need not be named)
- Fix slice instruction (uses highbit, not width)