### PR TITLE
Minor bug fixes regarding passes

### DIFF
--- a/src/btoropt/__main__.py
+++ b/src/btoropt/__main__.py
@@ -55,6 +55,8 @@ def main():
     
     assert btor2 is not None
 
+    base += 1
+
     # Check that the given pass names are valid
     for name in sys.argv[base:]:
         if find_pass(all_passes, name) is None:

--- a/src/btoropt/passes/transforms/initAllStates.py
+++ b/src/btoropt/passes/transforms/initAllStates.py
@@ -24,7 +24,7 @@ class InitAllStates(Pass):
     def __init__(self):
         super().__init__("init-all-states")
 
-    def run(p: list[Instruction]) -> list[Instruction]:
+    def run(self, p: list[Instruction]) -> list[Instruction]:
         res = []
         # start by extracting all states
         states: list[Instruction] = [s for s in p if isinstance(s, State)]

--- a/src/btoropt/passes/transforms/renameInputs.py
+++ b/src/btoropt/passes/transforms/renameInputs.py
@@ -27,7 +27,7 @@ class RenameInputs(Pass):
 
     # I chose to have this pass not modify p in place
     # you can also simply modify p and return it
-    def run(p: list[Instruction]) -> list[Instruction]:
+    def run(self, p: list[Instruction]) -> list[Instruction]:
         i = 0
         res = []
         for inst in p:

--- a/src/btoropt/passes/validation/checkLidOrdering.py
+++ b/src/btoropt/passes/validation/checkLidOrdering.py
@@ -24,7 +24,7 @@ class CheckLidOrdering(Pass):
     def __init__(self):
         super().__init__("check-lid-ordering")
 
-    def run(p: list[Instruction]) -> list[Instruction]:
+    def run(self, p: list[Instruction]) -> list[Instruction]:
         res = []
 
         for i in range(len(p)):


### PR DESCRIPTION
Fixing a few issues that I ran into when trying to run btor2-opt from the command line. The biggest one was the base variable in __main__ being off by one. The others are just missing 'self' args in the methods of the example Passes.