### PR TITLE
Better Parsing

### DIFF
--- a/src/btoropt/__init__.py
+++ b/src/btoropt/__init__.py
@@ -1,6 +1,6 @@
 ##########################################################################
 # BTOR2 parser, code optimizer, and circuit miter
-# Copyright (C) 2024  Amelia Dobis
+# Copyright (C) 2024-2025  Amelia Dobis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/btoropt/__main__.py
+++ b/src/btoropt/__main__.py
@@ -31,7 +31,8 @@ MODE_TYPE = Enum('Mode', [('Seq', 0), ('Modular', 1), ('Def', 2)])
 def main():
     # Retrieve flags
     if len(sys.argv) < 3:
-        print(f"Usage: btoropt [optional](--{MOD}, --{DEF}) <file.btor2> <pass_names_in_order> ...")
+        # print(f"Usage: btoropt [optional](--{MOD}, --{DEF}) <file.btor2> <pass_names_in_order> ...")
+        print(f"Usage: btoropt [optional](--{DEF}) <file.btor2> <pass_names_in_order> ...")
         exit(1)
 
     # Check options
@@ -45,8 +46,11 @@ def main():
             print(f"Invalid option given: {option}")
             exit(1)
         else:
+            # mode = \
+            #     MODE_TYPE.Modular if option == MOD else \
+            #     MODE_TYPE.Def     if option == DEF else \
+            #     MODE_TYPE.Seq
             mode = \
-                MODE_TYPE.Modular if option == MOD else \
                 MODE_TYPE.Def     if option == DEF else \
                 MODE_TYPE.Seq
         base += 1

--- a/src/btoropt/__main__.py
+++ b/src/btoropt/__main__.py
@@ -24,14 +24,14 @@ from enum import Enum
 import sys
 
 MOD = 'modular'
-PAR = 'par'
-options = [MOD, PAR]
-MODE_TYPE = Enum('Mode', [('Seq', 0), ('Modular', 1), ('Par', 2)])
+DEF = 'def'
+options = [MOD, DEF]
+MODE_TYPE = Enum('Mode', [('Seq', 0), ('Modular', 1), ('Def', 2)])
 
 def main():
     # Retrieve flags
     if len(sys.argv) < 3:
-        print(f"Usage: btoropt [optional](--{MOD}, --{PAR}) <file.btor2> <pass_names_in_order> ...")
+        print(f"Usage: btoropt [optional](--{MOD}, --{DEF}) <file.btor2> <pass_names_in_order> ...")
         exit(1)
 
     # Check options
@@ -47,7 +47,7 @@ def main():
         else:
             mode = \
                 MODE_TYPE.Modular if option == MOD else \
-                MODE_TYPE.Par     if option == PAR else \
+                MODE_TYPE.Def     if option == DEF else \
                 MODE_TYPE.Seq
         base += 1
         
@@ -64,8 +64,8 @@ def main():
         btor2 = parser.parse_file(btor2str)
     else:
         parser = Parser(btor2str)
-        if mode == MODE_TYPE.Par:
-            btor2 = parser.parsePar()
+        if mode == MODE_TYPE.Def:
+            btor2 = parser.parseDeferred()
         else:
             btor2 = parser.parseSeq()
     

--- a/src/btoropt/__main__.py
+++ b/src/btoropt/__main__.py
@@ -1,6 +1,6 @@
 ##########################################################################
 # BTOR2 parser, code optimizer, and circuit miter
-# Copyright (C) 2024  Amelia Dobis
+# Copyright (C) 2024-2025  Amelia Dobis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/btoropt/modparser.py
+++ b/src/btoropt/modparser.py
@@ -69,7 +69,7 @@ class ModParser(Parser):
         assert self.check_name(ref_mod), f"Named module {ref_mod} is undefined!"
 
         module = self.get_module(ref_mod)
-        val = self.find_inst(module.body, int(inst[3]))
+        val = get_inst(module.body, int(inst[3]))
         return Ref(int(inst[0]), ref_mod, val)
 
     # Parse a module's pre-scanned body

--- a/src/btoropt/modparser.py
+++ b/src/btoropt/modparser.py
@@ -20,6 +20,11 @@ from .program import *
 from parser import *
 from tqdm import tqdm
 
+# Old API for module parsing
+def parse_file(file: list[str]) -> Program:
+    parser = ModParser(file)
+    return parser.parse_file()
+
 # Special parser that handles custom instructions
 class ModParser(Parser):
     def __init__(self, p_str):

--- a/src/btoropt/modparser.py
+++ b/src/btoropt/modparser.py
@@ -1,6 +1,6 @@
 ##########################################################################
 # BTOR2 parser, code optimizer, and circuit miter
-# Copyright (C) 2024  Amelia Dobis
+# Copyright (C) 2024-2025  Amelia Dobis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/btoropt/modparser.py
+++ b/src/btoropt/modparser.py
@@ -1,0 +1,171 @@
+##########################################################################
+# BTOR2 parser, code optimizer, and circuit miter
+# Copyright (C) 2024  Amelia Dobis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+##########################################################################
+
+from .program import *
+from parser import *
+from tqdm import tqdm
+
+# Special parser that handles custom instructions
+class ModParser(Parser):
+    def __init__(self, p_str):
+        super().__init__(p_str)
+        self.modules: list[Module] = []
+        self.contracts: list[Contract] = []
+
+    # Checks thaa a given module name has been defined
+    def check_name(self, name: str) -> bool:
+        return name in [m.name for m in self.modules]
+
+    # Retrives a module by name from a list of parsed modules
+    def get_module(self, name: str) -> Module:
+        return [m for m in self.modules if m.name == name][0]
+
+    # Extracts a body from an arbitrary code sequence
+    # Returns the line idx at which the scanning ended
+    def scan_body(self, i: int) -> tuple[list[str], int]:
+        res = []
+        l = self.p_str[i].split(" ")
+        ## Check that the declaration line ends with an '{'
+        assert str(l[len(l)-1].strip()) == '{', f"invalid body start: {l[len(l)-1]}"
+
+        i += 1
+        while self.p_str[i].strip() != "}":
+            # Check that there are no nested structures
+            lid = self.p_str[i].strip().split(" ")[0]
+            assert lid.isnumeric(), f"All body lines must be instructions! Found: {lid}"
+            res.append(self.p_str[i].strip())
+            i += 1
+        return (res, i)
+
+    # Parses a ref instruction (only custom inst that is allowed in both modules and contracts)
+    # @param inst: the pre-split ref instruction to be parsed
+    # @param modules: the list of already parsed modules that can be referenced
+    def parse_ref(self, inst: list[str]) -> Ref:
+        ## Sanity check: Must be a ref instruction
+        assert inst[1] == "ref", f"`parse_ref` can only handle ref instructions, not {inst[1]}!"
+        ref_mod = inst[2]
+
+        ## Sanity check: check that the name exists
+        assert self.check_name(ref_mod), f"Named module {ref_mod} is undefined!"
+
+        module = self.get_module(ref_mod)
+        val = self.find_inst(module.body, int(inst[3]))
+        return Ref(int(inst[0]), ref_mod, val)
+
+    # Parse a module's pre-scanned body
+    # @param body: the list of instructions contained within the body
+    # @param modules: the list of already parsed modules that can be referenced
+    def parse_module_body(self, body: list[str]) -> list[Instruction]:
+        bodyParser = Parser()
+
+        for line in body:
+            inst = line.split(" ")
+            if inst[0] == ";": # handle comments
+                continue
+            lid = int(inst[0])
+            tag = inst[1]
+            match tag:
+                # Handle special instructions
+                case "inst":
+                    instd_mod = inst[2]
+                    ## Sanity check: check that the name exists
+                    assert self.check_name(instd_mod), f"Named module {instd_mod} is undefined!"
+                    bodyParser.p.append(Instance(lid, instd_mod))
+
+                case "ref":
+                    bodyParser.p.append(self.parse_ref(inst))
+
+                case "set":
+                    instance = bodyParser.find_inst(int(inst[2]))
+                    ref = bodyParser.find_inst(int(inst[3]))
+                    assert ref.name == instance.name, "`set` can only set a reference to an instance input!"
+                    alias = bodyParser.find_inst(int(inst[4]))
+                    bodyParser.p.append(Set(lid, instance, ref, alias))
+
+                # Handle standard instructions
+                case _:
+                    bodyParser.parse_inst(line)
+
+        return bodyParser.p
+
+    # Parse a contract's pre-scanned body
+    # @param name: the name given to the module
+    # @param body: the list of instructions contained within the body
+    # @param modules: the list of already parsed modules that can be referenced
+    def parse_contract_body(self, body: list[str]) -> list[Instruction]:
+        bodyParser = Parser()
+        for line in body:
+            inst = line.split(" ")
+            if inst[0] == ";": # handle comments
+                continue
+            lid = int(inst[0])
+            tag = inst[1]
+            match tag:
+                # Handle special instructions
+                case "prec":
+                    # Find the op associated to this instruction
+                    cond = bodyParser.find_inst(int(inst[2]))
+                    bodyParser.p.append(Prec(lid, cond))
+
+                case "post":
+                    # Find the op associated to this instruction
+                    cond = bodyParser.find_inst(int(inst[2]))
+                    bodyParser.p.append(Post(lid, cond))
+
+                case "ref":
+                    bodyParser.p.append(self.parse_ref(inst))
+
+                # Handle standard instructions
+                case _:
+                    bodyParser.parse_inst(line)
+
+        return bodyParser.p
+
+    # Parse an entire file that can contain contracts and modules
+    def parse_file(self, inp: list[str]) -> Program:
+        i = 0
+        while i < len(inp):
+            symbols = inp[i].strip().split(" ")
+            # Check whether it's a module or a contract
+            tag = symbols[0]
+            match tag:
+                case "module":
+                    name = symbols[1]
+                    # Scan and parse the body
+                    (body, i) = self.scan_body(inp, i)
+                    b = self.parse_module_body(body)
+                    # Create and store the module
+                    self.modules.append(Module(name, b))
+
+                case "contract":
+                    name = symbols[1]
+                    assert self.check_name(name), f"Contract name {name} is not defined!"
+                    (body, i) = self.scan_body(inp, i)
+                    body = self.parse_contract_body(body)
+                    # Create and store the module
+                    self.contracts.append(Contract(name, body))
+
+                case "}":
+                    i+=1
+                    continue
+
+                case _:
+                    print(f"Unsupported structure: {tag} is not module | contract")
+                    exit(1)
+
+        return Program(self.modules, self.contracts)

--- a/src/btoropt/modparser.py
+++ b/src/btoropt/modparser.py
@@ -137,17 +137,17 @@ class ModParser(Parser):
         return bodyParser.p
 
     # Parse an entire file that can contain contracts and modules
-    def parse_file(self, inp: list[str]) -> Program:
+    def parse_file(self) -> Program:
         i = 0
-        while i < len(inp):
-            symbols = inp[i].strip().split(" ")
+        while i < len(self.p_str):
+            symbols = self.p_str[i].strip().split(" ")
             # Check whether it's a module or a contract
             tag = symbols[0]
             match tag:
                 case "module":
                     name = symbols[1]
                     # Scan and parse the body
-                    (body, i) = self.scan_body(inp, i)
+                    (body, i) = self.scan_body(self.p_str, i)
                     b = self.parse_module_body(body)
                     # Create and store the module
                     self.modules.append(Module(name, b))
@@ -155,7 +155,7 @@ class ModParser(Parser):
                 case "contract":
                     name = symbols[1]
                     assert self.check_name(name), f"Contract name {name} is not defined!"
-                    (body, i) = self.scan_body(inp, i)
+                    (body, i) = self.scan_body(self.p_str, i)
                     body = self.parse_contract_body(body)
                     # Create and store the module
                     self.contracts.append(Contract(name, body))

--- a/src/btoropt/modparser.py
+++ b/src/btoropt/modparser.py
@@ -17,7 +17,7 @@
 ##########################################################################
 
 from .program import *
-from parser import *
+from .parser import *
 from tqdm import tqdm
 
 # Old API for module parsing
@@ -76,7 +76,7 @@ class ModParser(Parser):
     # @param body: the list of instructions contained within the body
     # @param modules: the list of already parsed modules that can be referenced
     def parse_module_body(self, body: list[str]) -> list[Instruction]:
-        bodyParser = Parser()
+        bodyParser = Parser(body)
 
         for line in body:
             inst = line.split(" ")
@@ -113,7 +113,7 @@ class ModParser(Parser):
     # @param body: the list of instructions contained within the body
     # @param modules: the list of already parsed modules that can be referenced
     def parse_contract_body(self, body: list[str]) -> list[Instruction]:
-        bodyParser = Parser()
+        bodyParser = Parser(body)
         for line in body:
             inst = line.split(" ")
             if inst[0] == ";": # handle comments
@@ -152,7 +152,7 @@ class ModParser(Parser):
                 case "module":
                     name = symbols[1]
                     # Scan and parse the body
-                    (body, i) = self.scan_body(self.p_str, i)
+                    (body, i) = self.scan_body(i)
                     b = self.parse_module_body(body)
                     # Create and store the module
                     self.modules.append(Module(name, b))
@@ -160,7 +160,7 @@ class ModParser(Parser):
                 case "contract":
                     name = symbols[1]
                     assert self.check_name(name), f"Contract name {name} is not defined!"
-                    (body, i) = self.scan_body(self.p_str, i)
+                    (body, i) = self.scan_body(i)
                     body = self.parse_contract_body(body)
                     # Create and store the module
                     self.contracts.append(Contract(name, body))

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -18,864 +18,742 @@
 
 from .program import *
 from tqdm import tqdm
+import multiprocessing
 
-# Retrieves an instruction with the given ID from the given standard program
-# This is a safe wrapper around `get_inst` and enforces that the given
-# ID must be correct.
-def find_inst(p: list[Instruction], id: int) -> Instruction:
-    inst = get_inst(p, id)
-    assert inst is not None, f"Undeclared instruction used with id: {id}"
-    return inst
+pool = multiprocessing.Pool()
 
-# Checks thaa a given module name has been defined
-def check_name(name: str, modules: list[Module]) -> bool:
-    return name in [m.name for m in modules]
+# Parses a given btor2 program
+class Parser:
+    # @param{p_str: list[str]}: list of lines to parse
+    def __init__(self, p_str: list[str]):
+        self.p = []
+        self.p_str = p_str
+        self.context = {}
 
-# Retrives a module by name from a list of parsed modules
-def get_module(name: str, modules: list[Module]) -> Module:
-    return [m for m in modules if m.name == name][0]
+    def clear(self):
+        self.p = []
+        self.p_str = []
+        self.context = {}
 
-# Extracts a body from an arbitrary code sequence
-# Returns the line idx at which the scanning ended
-def scan_body(inp: list[str], i: int) -> tuple[list[str], int]:
-    res = []
-    l = inp[i].split(" ")
-    ## Check that the declaration line ends with an '{'
-    assert str(l[len(l)-1].strip()) == '{', f"invalid body start: {l[len(l)-1]}"
+    def reset(self, p_str: list[str]):
+        self.p = []
+        self.p_str = p_str
+        self.context = {}
 
-    i += 1
-    while inp[i].strip() != "}":
-        # Check that there are no nested structures
-        lid = inp[i].strip().split(" ")[0]
-        assert lid.isnumeric(), f"All body lines must be instructions! Found: {lid}"
-        res.append(inp[i].strip())
-        i += 1
-    return (res, i)
+    # Retrieves an instruction with the given ID from the given standard program
+    # This is a safe wrapper around `get_inst` and enforces that the given
+    # ID must be correct.
+    def find_inst(self, id: int) -> Instruction:
+        inst = get_inst(self.p, id)
+        assert inst is not None, f"Undeclared instruction used with id: {id}"
+        return inst
 
-# Parses a ref instruction (only custom inst that is allowed in both modules and contracts)
-# @param inst: the pre-split ref instruction to be parsed
-# @param modules: the list of already parsed modules that can be referenced
-def parse_ref(inst: list[str], modules: list[Module]) -> Ref:
-    ## Sanity check: Must be a ref instruction
-    assert inst[1] == "ref", f"`parse_ref` can only handle ref instructions, not {inst[1]}!"
-    ref_mod = inst[2]
-
-    ## Sanity check: check that the name exists
-    assert check_name(ref_mod, modules), f"Named module {ref_mod} is undefined!"
-
-    module = get_module(ref_mod, modules)
-    val = find_inst(module.body, int(inst[3]))
-    return Ref(int(inst[0]), ref_mod, val)
-
-# Parse a module's pre-scanned body
-# @param body: the list of instructions contained within the body
-# @param modules: the list of already parsed modules that can be referenced
-def parse_module_body(body: list[str], modules: list[Module]) -> list[Instruction]:
-    p = []
-    for line in body:
+    # Parses a single instruction
+    # @param line: the current instruction that needs to be parsed
+    # @param p: the current parsed state of the program
+    def parse_inst(self, line: str) -> Instruction:
         inst = line.split(" ")
-        if inst[0] == ";": # handle comments
-            continue
+        # BTOR comment
+        if inst[0] == ";":
+            return None
         lid = int(inst[0])
         tag = inst[1]
+
+        # Check if tag is valid
+        assert tag in tags, f"Unsupported operation type: {tag} in {line}"
+
+        # Create the instruction associated to the tag
+        op = None
+
         match tag:
-            # Handle special instructions
-            case "inst":
-                instd_mod = inst[2]
-                ## Sanity check: check that the name exists
-                assert check_name(instd_mod, modules), f"Named module {instd_mod} is undefined!"
-                p.append(Instance(lid, instd_mod))
+            case "sort":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "sort instruction must be of the form: <lid> sort \{bitvector|array\} <width>. Found: " + line
+                assert inst[2] in sort_tags,\
+                    f"sort must be of type bitvector or array! Found: {inst[2]}"
 
-            case "ref":
-                p.append(parse_ref(inst, modules))
+                # Construct instruction
+                op = Sort(lid, inst[2], int(inst[3]))
 
-            case "set":
-                instance = find_inst(p, int(inst[2]))
-                ref = find_inst(p, int(inst[3]))
-                assert ref.name == instance.name, "`set` can only set a reference to an instance input!"
-                alias = find_inst(p, int(inst[4]))
-                p.append(Set(lid, instance, ref, alias))
 
-            # Handle standard instructions
-            case _:
-                op = parse_inst(line, p)
-                if op is not None:
-                    p.append(op)
+            case "input":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "input instruction must be of the form: <lid> input <sid> [<name>]. Found: " + line
 
-    return p
+                # Find the sort associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                assert isinstance(sort, Sort), f"Input sort must be a Sort. Found: " + line
 
-# Parse a contract's pre-scanned body
-# @param name: the name given to the module
-# @param body: the list of instructions contained within the body
-# @param modules: the list of already parsed modules that can be referenced
-def parse_contract_body(body: list[str], modules: list[Module]) -> list[Instruction]:
-    p = []
-    for line in body:
-        inst = line.split(" ")
-        if inst[0] == ";": # handle comments
-            continue
-        lid = int(inst[0])
-        tag = inst[1]
-        match tag:
-            # Handle special instructions
-            case "prec":
+                if len(inst) >= 4:
+                    name = inst[3].strip()
+                else:
+                    name = f"input_{inst[0]}"
+                # Construct instruction
+                op = Input(lid, sort, name)
+
+            case "output":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "output instruction must be of the form: <lid> output <opid> [name]. Found: " + line
+
                 # Find the op associated to this instruction
-                cond = find_inst(p, int(inst[2]))
-                p.append(Prec(lid, cond))
+                out = self.find_inst(int(inst[2]))
 
-            case "post":
+                if len(inst) >= 4:
+                    name = inst[3].strip()
+                else:
+                    name = f"output_{inst[0]}"
+
+                # Construct instruction
+                op = Output(lid, out, name)
+
+            case "bad":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "sort instruction must be of the form: <lid> bad <opid>. Found: " + line
+
                 # Find the op associated to this instruction
-                cond = find_inst(p, int(inst[2]))
-                p.append(Post(lid, cond))
-
-            case "ref":
-                p.append(parse_ref(inst, modules))
-
-            # Handle standard instructions
-            case _:
-                op = parse_inst(line, p)
-                if op is not None:
-                    p.append(op)
-
-    return p
-
-# Parses a single instruction
-# @param line: the current instruction that needs to be parsed
-# @param p: the current parsed state of the program
-def parse_inst(line: str, p: list[Instruction]) -> Instruction:
-    inst = line.split(" ")
-    # BTOR comment
-    if inst[0] == ";":
-        return None
-    lid = int(inst[0])
-    tag = inst[1]
-
-    # Check if tag is valid
-    assert tag in tags, f"Unsupported operation type: {tag} in {line}"
-
-    # Create the instruction associated to the tag
-    op = None
-
-    match tag:
-        case "sort":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "sort instruction must be of the form: <lid> sort \{bitvector|array\} <width>. Found: " + line
-            assert inst[2] in sort_tags,\
-                f"sort must be of type bitvector or array! Found: {inst[2]}"
-
-            # Construct instruction
-            op = Sort(lid, inst[2], int(inst[3]))
-
-
-        case "input":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "input instruction must be of the form: <lid> input <sid> [<name>]. Found: " + line
-
-            # Find the sort associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            assert isinstance(sort, Sort), f"Input sort must be a Sort. Found: " + line
-
-            if len(inst) >= 4:
-                name = inst[3].strip()
-            else:
-                name = f"input_{inst[0]}"
-            # Construct instruction
-            op = Input(lid, sort, name)
-
-        case "output":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "output instruction must be of the form: <lid> output <opid> [name]. Found: " + line
-
-            # Find the op associated to this instruction
-            out = find_inst(p, int(inst[2]))
-
-            if len(inst) >= 4:
-                name = inst[3].strip()
-            else:
-                name = f"output_{inst[0]}"
-
-            # Construct instruction
-            op = Output(lid, out, name)
-
-        case "bad":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "sort instruction must be of the form: <lid> bad <opid>. Found: " + line
-
-            # Find the op associated to this instruction
-            cond = find_inst(p, int(inst[2]))
-
-            # Construct instruction
-            op = Bad(lid, cond)
-
-        case "constraint":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "sort instruction must be of the form: <lid> constraint <opid>. Found: " + line
-
-            # Find the op associated to this instruction
-            cond = find_inst(p, int(inst[2]))
-
-            # Construct instruction
-            op = Constraint(lid, cond)
-
-        case "zero":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "sort instruction must be of the form: <lid> zero <sid>. Found: " + line
-
-            # Find the sort associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-
-            # Construct instruction
-            op = Zero(lid, sort)
-
-        case "one":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "sort instruction must be of the form: <lid> one <sid>. Found: " + line
-
-            # Find the sort associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-
-            # Construct instruction
-            op = One(lid, sort)
-
-        case "ones":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "sort instruction must be of the form: <lid> ones <sid>. Found: " + line
-
-            # Find the sort associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-
-            # Construct instruction
-            op = Ones(lid, sort)
-
-        case "constd":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "sort instruction must be of the form: <lid> constd <sid> <value>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            value = int(inst[3])
-
-            # Construct instruction
-            op = Constd(lid, sort, value)
-
-        case "consth":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "sort instruction must be of the form: <lid> consth <sid> <value>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            value = int(inst[3])
-
-            # Construct instruction
-            op = Consth(lid, sort, value)
-
-        case "const":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "sort instruction must be of the form: <lid> const <sid> <value>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            # Default base is 2
-            value = int(inst[3], 2)
-
-            # Construct instruction
-            op = Const(lid, sort, value)
-
-        case "state":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 3,\
-                "state instruction must be of the form: <lid> state <sid> [<name>]. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            assert isinstance(sort, Sort), f"State sort must be a Sort. Found: " + line
-            if len(inst) >= 4:
-                name = inst[3].strip()
-            else:
-                name = f"state_{inst[0]}"
-
-            # Construct instruction
-            op = State(lid, sort, name)
-
-        case "init":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> init <sid> <stateid> <valueid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            state = find_inst(p, int(inst[3]))
-            val = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Init(lid, sort, state, val)
-
-        case "next":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> next <sid> <stateid> <nextid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            state = find_inst(p, int(inst[3]))
-            next = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Next(lid, sort, state, next)
-
-        case "slice":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 6,\
-                "slice instruction must be of the form: <lid> slice <sid> <opid> <highbit> <lowbit>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            operand = find_inst(p, int(inst[3]))
-            highbit = int(inst[4])
-            lowbit = int(inst[5])
-
-            # Construct instruction
-            op = Slice(lid, sort, operand, highbit, lowbit)
-
-        case "ite":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 6,\
-                "sort instruction must be of the form: <lid> ite <sid> <condid> <tid> <fid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            cond = find_inst(p, int(inst[3]))
-            t = find_inst(p, int(inst[4]))
-            f = find_inst(p, int(inst[5]))
-
-            # Construct instruction
-            op = Ite(lid, sort, cond, t, f)
-
-        case "implies":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> implies <sid> <lhsid> <rhsid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            lhs = find_inst(p, int(inst[3]))
-            rhs = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Implies(lid, sort, lhs, rhs)
-
-        case "iff":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> iff <sid> <lhsid> <rhsid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            lhs = find_inst(p, int(inst[3]))
-            rhs = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Iff(lid, sort, lhs, rhs)
-
-        case "add":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> add <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Add(lid, sort, op1, op2)
-
-        case "sub":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> sub <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Sub(lid, sort, op1, op2)
-
-        case "mul":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> mul <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Mul(lid, sort, op1, op2)
-
-        case "sdiv":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> sdiv <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Sdiv(lid, sort, op1, op2)
-
-        case "udiv":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> udiv <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Udiv(lid, sort, op1, op2)
-
-        case "smod":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> smod <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Smod(lid, sort, op1, op2)
-
-        case "srem":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> srem <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Srem(lid, sort, op1, op2)
-
-        case "urem":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> urem <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Urem(lid, sort, op1, op2)
-
-
-        case "sll":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> sll <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Sll(lid, sort, op1, op2)
-
-        case "srl":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> srl <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Srl(lid, sort, op1, op2)
-
-        case "sra":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> sra <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Sra(lid, sort, op1, op2)
-
-        case "and":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> and <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = And(lid, sort, op1, op2)
-
-        case "or":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> or <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Or(lid, sort, op1, op2)
-
-        case "xor":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> xor <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Xor(lid, sort, op1, op2)
-
-        case "concat":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> concat <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Concat(lid, sort, op1, op2)
-
-        case "not":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "not instruction must be of the form: <lid> not <sid> <cond>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            cond = find_inst(p, int(inst[3]))
-
-            # Construct instruction
-            op = Not(lid, sort, cond)
-
-        case "inc":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "inc instruction must be of the form: <lid> inc <sid> <stateid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            state = find_inst(p, int(inst[3]))
-
-            # Construct instruction
-            op = Inc(lid, sort, state)
-
-        case "dec":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "dec instruction must be of the form: <lid> dec <sid> <stateid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            state = find_inst(p, int(inst[3]))
-
-            # Construct instruction
-            op = Dec(lid, sort, state)
-
-        case "neg":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "neg instruction must be of the form: <lid> neg <sid> <cond>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            cond = find_inst(p, int(inst[3]))
-
-            # Construct instruction
-            op = Neg(lid, sort, cond)
-
-        case "redor":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "redor instruction must be of the form: <lid> redor <srtid> <sid>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            cond = find_inst(p, int(inst[3]))
-
-            # Construct instruction
-            op = Redor(lid, sort, cond)
-
-        case "redand":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "redand instruction must be of the form: <lid> redand <srtid> <sid>. Found: " + line
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            cond = find_inst(p, int(inst[3]))
-            # Construct instruction
-            op = Redand(lid, sort, cond)
-        case "redxor":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 4,\
-                "redxor instruction must be of the form: <lid> redxor <srtid> <sid>. Found: " + line
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            cond = find_inst(p, int(inst[3]))
-            # Construct instruction
-            op = Redxor(lid, sort, cond)
-
-        case "eq":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> eq <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Eq(lid, sort, op1, op2)
-
-        case "neq":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> neq <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Neq(lid, sort, op1, op2)
-
-        case "ugt":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> ugt <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Ugt(lid, sort, op1, op2)
-
-        case "sgt":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> sgt <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Sgt(lid, sort, op1, op2)
-
-        case "ugte":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> ugte <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Ugte(lid, sort, op1, op2)
-
-        case "sgte":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> sgte <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Sgte(lid, sort, op1, op2)
-
-        case "ult":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> ult <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Ult(lid, sort, op1, op2)
-
-        case "slt":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> slt <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Slt(lid, sort, op1, op2)
-
-        case "ulte":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> ulte <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Ulte(lid, sort, op1, op2)
-
-        case "slte":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sort instruction must be of the form: <lid> slte <sid> <op1> <op2>. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            op1 = find_inst(p, int(inst[3]))
-            op2 = find_inst(p, int(inst[4]))
-
-            # Construct instruction
-            op = Slte(lid, sort, op1, op2)
-
-        case "uext":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "uext instruction must be of the form: <lid> uext <sid> <opid> <width> [<name>]. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            operand = find_inst(p, int(inst[3]))
-            width = int(inst[4])
-
-            if len(inst) >= 6:
-                name = inst[5].strip()
-            else:
-                name = f"uext_{inst[0]}"
-
-            # Construct instruction
-            op = Uext(lid, sort, operand, width, name)
-
-        case "sext":
-            # Sanity check: verify that instruction is well formed
-            assert len(inst) >= 5,\
-                "sext instruction must be of the form: <lid> sext <sid> <opid> <width> [<name>]. Found: " + line
-
-            # Find the operands associated to this instruction
-            sort = find_inst(p, int(inst[2]))
-            operand = find_inst(p, int(inst[3]))
-            width = int(inst[4])
-
-            if len(inst) >= 6:
-                name = inst[5].strip()
-            else:
-                name = f"sext_{inst[0]}"
-
-            # Construct instruction
-            op = Sext(lid, sort, operand, width, name)
-
-        case _:
-            print(f"Unsupported operation type: {tag} in {line}")
-            exit(1)
-    return op
-
-# Parse an entire file that can contain contracts and modules
-def parse_file(inp: list[str]) -> Program:
-    m: list[Module] = []
-    c: list[Contract] = []
-    i = 0
-    while i < len(inp):
-        symbols = inp[i].strip().split(" ")
-        # Check whether it's a module or a contract
-        tag = symbols[0]
-        match tag:
-            case "module":
-                name = symbols[1]
-                # Scan and parse the body
-                (body, i) = scan_body(inp, i)
-                b = parse_module_body(body, m)
-                # Create and store the module
-                m.append(Module(name, b))
-
-            case "contract":
-                name = symbols[1]
-                assert check_name(name, m), f"Contract name {name} is not defined!"
-                (body, i) = scan_body(inp, i)
-                body = parse_contract_body(body, m)
-                # Create and store the module
-                c.append(Contract(name, body))
-
-            case "}":
-                i+=1
-                continue
+                cond = self.find_inst(int(inst[2]))
+
+                # Construct instruction
+                op = Bad(lid, cond)
+
+            case "constraint":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "sort instruction must be of the form: <lid> constraint <opid>. Found: " + line
+
+                # Find the op associated to this instruction
+                cond = self.find_inst(int(inst[2]))
+
+                # Construct instruction
+                op = Constraint(lid, cond)
+
+            case "zero":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "sort instruction must be of the form: <lid> zero <sid>. Found: " + line
+
+                # Find the sort associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+
+                # Construct instruction
+                op = Zero(lid, sort)
+
+            case "one":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "sort instruction must be of the form: <lid> one <sid>. Found: " + line
+
+                # Find the sort associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+
+                # Construct instruction
+                op = One(lid, sort)
+
+            case "ones":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "sort instruction must be of the form: <lid> ones <sid>. Found: " + line
+
+                # Find the sort associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+
+                # Construct instruction
+                op = Ones(lid, sort)
+
+            case "constd":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "sort instruction must be of the form: <lid> constd <sid> <value>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                value = int(inst[3])
+
+                # Construct instruction
+                op = Constd(lid, sort, value)
+
+            case "consth":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "sort instruction must be of the form: <lid> consth <sid> <value>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                value = int(inst[3])
+
+                # Construct instruction
+                op = Consth(lid, sort, value)
+
+            case "const":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "sort instruction must be of the form: <lid> const <sid> <value>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                # Default base is 2
+                value = int(inst[3], 2)
+
+                # Construct instruction
+                op = Const(lid, sort, value)
+
+            case "state":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 3,\
+                    "state instruction must be of the form: <lid> state <sid> [<name>]. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                assert isinstance(sort, Sort), f"State sort must be a Sort. Found: " + line
+                if len(inst) >= 4:
+                    name = inst[3].strip()
+                else:
+                    name = f"state_{inst[0]}"
+
+                # Construct instruction
+                op = State(lid, sort, name)
+
+            case "init":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> init <sid> <stateid> <valueid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                state = self.find_inst(int(inst[3]))
+                val = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Init(lid, sort, state, val)
+
+            case "next":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> next <sid> <stateid> <nextid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                state = self.find_inst(int(inst[3]))
+                next = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Next(lid, sort, state, next)
+
+            case "slice":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 6,\
+                    "slice instruction must be of the form: <lid> slice <sid> <opid> <highbit> <lowbit>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                operand = self.find_inst(int(inst[3]))
+                highbit = int(inst[4])
+                lowbit = int(inst[5])
+
+                # Construct instruction
+                op = Slice(lid, sort, operand, highbit, lowbit)
+
+            case "ite":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 6,\
+                    "sort instruction must be of the form: <lid> ite <sid> <condid> <tid> <fid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                cond = self.find_inst(int(inst[3]))
+                t = self.find_inst(int(inst[4]))
+                f = self.find_inst(int(inst[5]))
+
+                # Construct instruction
+                op = Ite(lid, sort, cond, t, f)
+
+            case "implies":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> implies <sid> <lhsid> <rhsid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                lhs = self.find_inst(int(inst[3]))
+                rhs = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Implies(lid, sort, lhs, rhs)
+
+            case "iff":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> iff <sid> <lhsid> <rhsid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                lhs = self.find_inst(int(inst[3]))
+                rhs = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Iff(lid, sort, lhs, rhs)
+
+            case "add":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> add <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Add(lid, sort, op1, op2)
+
+            case "sub":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> sub <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Sub(lid, sort, op1, op2)
+
+            case "mul":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> mul <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Mul(lid, sort, op1, op2)
+
+            case "sdiv":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> sdiv <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Sdiv(lid, sort, op1, op2)
+
+            case "udiv":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> udiv <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Udiv(lid, sort, op1, op2)
+
+            case "smod":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> smod <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Smod(lid, sort, op1, op2)
+
+            case "srem":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> srem <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Srem(lid, sort, op1, op2)
+
+            case "urem":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> urem <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Urem(lid, sort, op1, op2)
+
+
+            case "sll":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> sll <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Sll(lid, sort, op1, op2)
+
+            case "srl":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> srl <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Srl(lid, sort, op1, op2)
+
+            case "sra":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> sra <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Sra(lid, sort, op1, op2)
+
+            case "and":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> and <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = And(lid, sort, op1, op2)
+
+            case "or":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> or <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Or(lid, sort, op1, op2)
+
+            case "xor":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> xor <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Xor(lid, sort, op1, op2)
+
+            case "concat":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> concat <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Concat(lid, sort, op1, op2)
+
+            case "not":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "not instruction must be of the form: <lid> not <sid> <cond>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                cond = self.find_inst(int(inst[3]))
+
+                # Construct instruction
+                op = Not(lid, sort, cond)
+
+            case "inc":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "inc instruction must be of the form: <lid> inc <sid> <stateid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                state = self.find_inst(int(inst[3]))
+
+                # Construct instruction
+                op = Inc(lid, sort, state)
+
+            case "dec":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "dec instruction must be of the form: <lid> dec <sid> <stateid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                state = self.find_inst(int(inst[3]))
+
+                # Construct instruction
+                op = Dec(lid, sort, state)
+
+            case "neg":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "neg instruction must be of the form: <lid> neg <sid> <cond>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                cond = self.find_inst(int(inst[3]))
+
+                # Construct instruction
+                op = Neg(lid, sort, cond)
+
+            case "redor":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "redor instruction must be of the form: <lid> redor <srtid> <sid>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                cond = self.find_inst(int(inst[3]))
+
+                # Construct instruction
+                op = Redor(lid, sort, cond)
+
+            case "redand":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "redand instruction must be of the form: <lid> redand <srtid> <sid>. Found: " + line
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                cond = self.find_inst(int(inst[3]))
+                # Construct instruction
+                op = Redand(lid, sort, cond)
+            case "redxor":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 4,\
+                    "redxor instruction must be of the form: <lid> redxor <srtid> <sid>. Found: " + line
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                cond = self.find_inst(int(inst[3]))
+                # Construct instruction
+                op = Redxor(lid, sort, cond)
+
+            case "eq":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> eq <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Eq(lid, sort, op1, op2)
+
+            case "neq":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> neq <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Neq(lid, sort, op1, op2)
+
+            case "ugt":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> ugt <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Ugt(lid, sort, op1, op2)
+
+            case "sgt":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> sgt <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Sgt(lid, sort, op1, op2)
+
+            case "ugte":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> ugte <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Ugte(lid, sort, op1, op2)
+
+            case "sgte":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> sgte <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Sgte(lid, sort, op1, op2)
+
+            case "ult":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> ult <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Ult(lid, sort, op1, op2)
+
+            case "slt":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> slt <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Slt(lid, sort, op1, op2)
+
+            case "ulte":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> ulte <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Ulte(lid, sort, op1, op2)
+
+            case "slte":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sort instruction must be of the form: <lid> slte <sid> <op1> <op2>. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                op1 = self.find_inst(int(inst[3]))
+                op2 = self.find_inst(int(inst[4]))
+
+                # Construct instruction
+                op = Slte(lid, sort, op1, op2)
+
+            case "uext":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "uext instruction must be of the form: <lid> uext <sid> <opid> <width> [<name>]. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                operand = self.find_inst(int(inst[3]))
+                width = int(inst[4])
+
+                if len(inst) >= 6:
+                    name = inst[5].strip()
+                else:
+                    name = f"uext_{inst[0]}"
+
+                # Construct instruction
+                op = Uext(lid, sort, operand, width, name)
+
+            case "sext":
+                # Sanity check: verify that instruction is well formed
+                assert len(inst) >= 5,\
+                    "sext instruction must be of the form: <lid> sext <sid> <opid> <width> [<name>]. Found: " + line
+
+                # Find the operands associated to this instruction
+                sort = self.find_inst(int(inst[2]))
+                operand = self.find_inst(int(inst[3]))
+                width = int(inst[4])
+
+                if len(inst) >= 6:
+                    name = inst[5].strip()
+                else:
+                    name = f"sext_{inst[0]}"
+
+                # Construct instruction
+                op = Sext(lid, sort, operand, width, name)
 
             case _:
-                print(f"Unsupported structure: {tag} is not module | contract")
+                print(f"Unsupported operation type: {tag} in {line}")
                 exit(1)
+        return op
 
-    return Program(m, c)
+    # Parses the entire program in parallel
+    def parsePar(self) -> list[Instruction]:
+        return pool.map(self.parse_inst, self.p_str)
 
-# Parse a standard btor2 file, does not handle custom instructions
-def parse(inp: list[str]) -> list[Instruction]:
-    # Split the string into instructions and read them 1 by 1
-    p = []
-    for line in tqdm(inp, desc="Parsing BTOR2"):
-        op = parse_inst(line, p)
-        if op is not None:
-            p.append(op)
-    return p
+    # Parse a standard btor2 file, does not handle custom instructions
+    def parseSeq(self) -> list[Instruction]:
+        # Split the string into instructions and read them 1 by 1
+        p = []
+        for line in tqdm(self.p_str, desc="Parsing BTOR2"):
+            op = self.parse_inst(line)
+            if op is not None:
+                p.append(op)
+        return p
+

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -26,8 +26,10 @@ pool = multiprocessing.Pool()
 def parse(p_str: list[str], par=False) -> list[Instruction]:
     parse = Parser(p_str)
     if par:
-        return parse.parsePar()
-    return parse.parseSeq()
+        parse.parsePar()
+    else: 
+        parse.parseSeq()
+    return parse.p 
 
 # Parses a given btor2 program
 class Parser:
@@ -50,7 +52,9 @@ class Parser:
     # ID must be correct.
     def find_inst(self, id: int) -> Instruction:
         inst = get_inst(self.p, id)
-        #assert inst is not None, f"Undeclared instruction used with id: {id}"
+        if inst is None:
+            print(self.p)
+            assert False, f"Undeclared instruction used with id: {id}"
         return inst
     
     # Defers the resolution of all operand IDs
@@ -785,7 +789,7 @@ class Parser:
         )
 
     # Parses the entire program in parallel
-    def parsePar(self) -> list[Instruction]:
+    def parsePar(self) -> None:
         assert not self.done, "Parser must be cleared before being reused!"
 
         self.p = pool.map(self.parse_inst, self.p_str)
@@ -801,19 +805,16 @@ class Parser:
 
 
     # Parse a standard btor2 file, does not handle custom instructions
-    def parseSeq(self) -> list[Instruction]:
+    def parseSeq(self) -> None:
         assert not self.done, "Parser must be cleared before being reused!"
 
         # Split the string into instructions and read them 1 by 1
-        p = []
         for line in tqdm(self.p_str, desc="Parsing BTOR2"):
             # Parse instructions in an eager manner
             op = self.parse_inst(line, deferred=False)
             if op is not None:
-                p.append(op)
+                self.p.append(op)
 
         # Parser is done parsing
         self.done = True
-        
-        return p
 

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -50,12 +50,12 @@ class Parser:
     # ID must be correct.
     def find_inst(self, id: int) -> Instruction:
         inst = get_inst(self.p, id)
-        assert inst is not None, f"Undeclared instruction used with id: {id}"
+        #assert inst is not None, f"Undeclared instruction used with id: {id}"
         return inst
     
     # Defers the resolution of all operand IDs
     def defer(self, ids: list[str]) -> list[Instruction]:
-        return map(lambda id: Instruction(int(id)), ids)
+        return list(map(lambda id: Instruction(int(id)), ids))
 
     # Parses a single instruction
     # @param line: the current instruction that needs to be parsed
@@ -781,7 +781,7 @@ class Parser:
     def resolveIds(self, inst: Instruction) -> Instruction:
         return Instruction( \
             inst.lid, inst.inst, \
-            map(lambda op: self.context.get(op.lid), inst.operands) \
+            list(map(lambda op: self.context.get(op.lid), inst.operands)) \
         )
 
     # Parses the entire program in parallel

--- a/src/btoropt/parser.py
+++ b/src/btoropt/parser.py
@@ -22,6 +22,13 @@ import multiprocessing
 
 pool = multiprocessing.Pool()
 
+# Trying to maintain original parser API
+def parse(p_str: list[str], par=False) -> list[Instruction]:
+    parse = Parser(p_str)
+    if par:
+        return parse.parsePar()
+    return parse.parseSeq()
+
 # Parses a given btor2 program
 class Parser:
     # @param{p_str: list[str]}: list of lines to parse

--- a/src/btoropt/program.py
+++ b/src/btoropt/program.py
@@ -1,6 +1,6 @@
 ##########################################################################
 # BTOR2 parser, code optimizer, and circuit miter
-# Copyright (C) 2024  Amelia Dobis
+# Copyright (C) 2024-2025  Amelia Dobis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/btoropt/program.py
+++ b/src/btoropt/program.py
@@ -423,7 +423,7 @@ class Set(Instruction):
 
 
 # Structural extensions
-class ModuleLike():
+class ModuleLike:
     def __init__(self, name: str, body: list[Instruction]) -> None:
         self.name = name
         self.body = body
@@ -452,7 +452,7 @@ class Contract(ModuleLike):
         
 
 # Base class for a custom btor2 file (standard is simply a list of instructions)
-class Program():
+class Program:
     def __init__(self, modules: list[Module], contracts: list[Contract]) -> None:
         self.modules = modules
         # Ignore all contracts that don't have an existing name

--- a/src/btoropt/program.py
+++ b/src/btoropt/program.py
@@ -46,7 +46,7 @@ structure_tags = ["module", "contract"]
 #   True: instruction is part of the btor2 spec
 #   False: instruction is a custom extension for btor-opt
 class Instruction:
-    def __init__(self, lid: int, inst: str, operands = [], is_standard=True):
+    def __init__(self, lid: int, inst: str | None = None, operands = [], is_standard=True):
         self.lid = lid
         self.inst = inst
         self.operands = operands

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,6 @@
-
 ##########################################################################
 # BTOR2 parser, code optimizer, and circuit miter
-# Copyright (C) 2024  Amelia Dobis
+# Copyright (C) 2024-2025  Amelia Dobis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/test.py
+++ b/tests/test.py
@@ -20,6 +20,7 @@
 import unittest
 
 from src.btoropt.parser import *
+from src.btoropt.modparser import *
 
 def parsewrapper (filepath):
     btor2str: list[str] = []

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,6 +39,29 @@ class BTORTestParser(unittest.TestCase):
 
         print("test passed")
 
+    def test_basic(self):
+        p = parse(["1 sort bitvector 1"])
+        self.assertEqual(p[0].inst, "sort")
+        self.assertEqual(len(p), 1)
+
+        print("test basic passed")
+
+    def test_simple(self):
+        p = parse([ \
+            "1 sort bitvector 1", \
+            "2 input 1 a", \
+            "3 const 1 1", \
+            "4 or 1 2 3", \
+            "5 eq 1 2 3", \
+            "6 not 1 5", \
+            "7 bad 6" \
+        ])
+        self.assertEqual(p[0].inst, "sort")
+        self.assertEqual(len(p), 7)
+
+        print("test simple passed")
+
+
     def test_modular(self):
             p: Program = parse_file(parsewrapper("tests/btor/modular.btor"))
             self.assertIsNotNone(p)

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,9 +27,13 @@ def parsewrapper (filepath):
         btor2str = f.readlines()
     return btor2str
 
+def reduce_p_str(p_str: list[str]) -> str:
+    return reduce(lambda acc, s: acc + s + "\n", p_str, "")
+
 class BTORTestParser(unittest.TestCase):
     """Check whether BTOR interface is working properly"""
-
+     
+    # Checks that a btor2 file produced by yosys can be parsed
     def test_standard(self):
         prgm = parse(parsewrapper("tests/btor/reg_en.btor"))
 
@@ -39,6 +43,7 @@ class BTORTestParser(unittest.TestCase):
 
         print("test passed")
 
+    # Checks that a single btor2 instruction can be parsed
     def test_basic(self):
         p = parse(["1 sort bitvector 1"])
         self.assertEqual(p[0].inst, "sort")
@@ -46,6 +51,7 @@ class BTORTestParser(unittest.TestCase):
 
         print("test basic passed")
 
+    # Checks that a simple btor2 model can be parsed
     def test_simple(self):
         p = parse([ \
             "1 sort bitvector 1", \
@@ -61,20 +67,57 @@ class BTORTestParser(unittest.TestCase):
 
         print("test simple passed")
 
+    # Checks that both par and simple parse the same
+    def test_deferred_serial(self):
+        s = [ \
+            "1 sort bitvector 1", \
+            "2 input 1 a", \
+            "3 const 1 1", \
+            "4 or 1 2 3", \
+            "5 eq 1 2 3", \
+            "6 not 1 5", \
+            "7 bad 6" \
+        ]
+        par_p = parse(s, deferred=True)
 
-    def test_modular(self):
-            p: Program = parse_file(parsewrapper("tests/btor/modular.btor"))
-            self.assertIsNotNone(p)
+        self.assertEqual(serialize_p(par_p), reduce_p_str(s))
 
-            self.assertEqual(len(p.modules), 2)
-            self.assertEqual(len(p.contracts), 1)
-            ma = p.get_module("A")
-            ca = p.get_contract("A")
-            self.assertIsNotNone(ca)
-            c = p.get_module_contract(ma)
-            self.assertIsNotNone(c)
-            self.assertEqual(c, ca)
-            self.assertEqual(c.name, "A")
+        print("test serilaization passed")
+
+    # Checks that both par and simple parse the same
+    def test_diff(self):
+        s = [ \
+            "1 sort bitvector 1", \
+            "2 input 1 a", \
+            "3 const 1 1", \
+            "4 or 1 2 3", \
+            "5 eq 1 2 3", \
+            "6 not 1 5", \
+            "7 bad 6" \
+        ]
+        seq_p = parse(s)
+        par_p = parse(s, deferred=True)
+        
+        self.assertEqual(len(seq_p), len(par_p))   
+        for i in range(len(seq_p)):
+            self.assertEqual(seq_p[i], par_p[i])
+
+        print("differential test passed")
+
+
+    # def test_modular(self):
+    #         p: Program = parse_file(parsewrapper("tests/btor/modular.btor"))
+    #         self.assertIsNotNone(p)
+
+    #         self.assertEqual(len(p.modules), 2)
+    #         self.assertEqual(len(p.contracts), 1)
+    #         ma = p.get_module("A")
+    #         ca = p.get_contract("A")
+    #         self.assertIsNotNone(ca)
+    #         c = p.get_module_contract(ma)
+    #         self.assertIsNotNone(c)
+    #         self.assertEqual(c, ca)
+    #         self.assertEqual(c.name, "A")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The goal of this PR is to tackle issue #13 and make parsing less horrifically slow. This is done by refactoring the implementation of the parser to avoid constant copying of the parsed program, and offering a new parsing option to defer resolution of line IDs (to yield actual instructions in place of an operand ID) until after the entire program is parsed (this avoids repeated instruction lookups). 

Hopefully this will be useful and 